### PR TITLE
Add basic WordPress client package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# WPMCP
+
+WPMCP aims to provide a **Management Control Panel (MCP)** server for automating administrative WordPress tasks through the WordPress REST API. The server is written in Python and acts as a central interface for managing multiple WordPress installations.
+
+## Objectives
+
+- Offer a simple RESTful service that wraps WordPress operations such as plugin management, user administration and site configuration.
+- Use the standard WordPress REST API so administrators can integrate with existing sites without additional plugins.
+- Provide secure authentication options that fit a variety of WordPress setups.
+
+## Installation
+
+### Requirements
+
+- Python 3.12 or newer
+- `requests` and any other dependencies listed in `requirements.txt`
+
+Install the required packages:
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+### Initial setup
+
+1. Clone this repository.
+2. Install dependencies as above.
+3. Prepare configuration for your WordPress instances (to be defined in future versions).
+
+Once these steps are complete you will be ready to run the MCP server (implementation forthcoming).
+
+## WordPress REST API overview
+
+WordPress exposes most administrative functionality through its REST API at `/wp-json/wp/v2/`. It supports actions like retrieving posts, managing users and installing plugins. For this MCP server, the API will be leveraged to perform administrative tasks automatically.
+
+### Authentication methods
+
+Several authentication approaches can be used with the WordPress REST API:
+
+1. **Cookie authentication** – relies on WordPress login cookies and is mainly suited for browser-based clients.
+2. **Application passwords** – built-in feature enabling basic authentication using a generated password per user. Works over HTTPS and is simple to integrate.
+3. **OAuth or JWT plugins** – third-party plugins offer OAuth 1.0a, OAuth2 or JWT token authentication when more robust solutions are required.
+
+Depending on your environment you can pick whichever method suits your security and automation needs.
+
+## Usage
+
+```python
+from wpmcp.client import WordPressClient
+
+client = WordPressClient("https://example.com/wp-json")
+posts = client.get("wp/v2/posts")
+print(posts)
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 # Requirements for Python 3.12 or later
+requests>=2.0

--- a/wpmcp/client.py
+++ b/wpmcp/client.py
@@ -1,0 +1,40 @@
+import requests
+from typing import Any, Dict, Optional
+
+
+class WordPressClient:
+    """Simple wrapper for the WordPress REST API."""
+
+    def __init__(self, base_url: str, token: Optional[str] = None) -> None:
+        """Initialize the client with a base URL and optional auth token."""
+        self.base_url = base_url.rstrip('/')
+        self.session = requests.Session()
+        if token:
+            self.session.headers.update({"Authorization": f"Bearer {token}"})
+
+    def _request(self, method: str, endpoint: str, **kwargs: Any) -> requests.Response:
+        """Send an HTTP request and return the raw response."""
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        response = self.session.request(method, url, **kwargs)
+        response.raise_for_status()
+        return response
+
+    def get(self, endpoint: str, **kwargs: Any) -> Dict[str, Any]:
+        """Perform a GET request and return the parsed JSON data."""
+        response = self._request("GET", endpoint, **kwargs)
+        return response.json()
+
+    def post(self, endpoint: str, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
+        """Perform a POST request with JSON data and return the parsed response."""
+        response = self._request("POST", endpoint, json=data, **kwargs)
+        return response.json()
+
+    def put(self, endpoint: str, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
+        """Perform a PUT request with JSON data and return the parsed response."""
+        response = self._request("PUT", endpoint, json=data, **kwargs)
+        return response.json()
+
+    def delete(self, endpoint: str, **kwargs: Any) -> Dict[str, Any]:
+        """Perform a DELETE request and return the parsed JSON data."""
+        response = self._request("DELETE", endpoint, **kwargs)
+        return response.json()


### PR DESCRIPTION
## Summary
- merge README from `main` and include usage example
- implement a simple WordPress REST API client

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_687651ddcc9483238cf241a025baa7f5