### PR TITLE
Add basic WordPress client package

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ Several authentication approaches can be used with the WordPress REST API:
 
 Depending on your environment you can pick whichever method suits your security and automation needs.
 
+## Usage
+
+```python
+from wpmcp.client import WordPressClient
+
+client = WordPressClient("https://example.com/wp-json")
+posts = client.get("wp/v2/posts")
+print(posts)
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 # Requirements for Python 3.12 or later
+requests>=2.0

--- a/wpmcp/client.py
+++ b/wpmcp/client.py
@@ -1,0 +1,40 @@
+import requests
+from typing import Any, Dict, Optional
+
+
+class WordPressClient:
+    """Simple wrapper for the WordPress REST API."""
+
+    def __init__(self, base_url: str, token: Optional[str] = None) -> None:
+        """Initialize the client with a base URL and optional auth token."""
+        self.base_url = base_url.rstrip('/')
+        self.session = requests.Session()
+        if token:
+            self.session.headers.update({"Authorization": f"Bearer {token}"})
+
+    def _request(self, method: str, endpoint: str, **kwargs: Any) -> requests.Response:
+        """Send an HTTP request and return the raw response."""
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        response = self.session.request(method, url, **kwargs)
+        response.raise_for_status()
+        return response
+
+    def get(self, endpoint: str, **kwargs: Any) -> Dict[str, Any]:
+        """Perform a GET request and return the parsed JSON data."""
+        response = self._request("GET", endpoint, **kwargs)
+        return response.json()
+
+    def post(self, endpoint: str, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
+        """Perform a POST request with JSON data and return the parsed response."""
+        response = self._request("POST", endpoint, json=data, **kwargs)
+        return response.json()
+
+    def put(self, endpoint: str, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
+        """Perform a PUT request with JSON data and return the parsed response."""
+        response = self._request("PUT", endpoint, json=data, **kwargs)
+        return response.json()
+
+    def delete(self, endpoint: str, **kwargs: Any) -> Dict[str, Any]:
+        """Perform a DELETE request and return the parsed JSON data."""
+        response = self._request("DELETE", endpoint, **kwargs)
+        return response.json()


### PR DESCRIPTION
## Summary
- merge README from `main` and include usage example
- implement a simple WordPress REST API client

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_687651ddcc9483238cf241a025baa7f5